### PR TITLE
Add token authentication to API books controller

### DIFF
--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -1,69 +1,75 @@
-# app/controllers/api/v1/books_controller.rb
 module Api
-    module V1
-      class BooksController < ApplicationController
-        # Skip CSRF token verification for API requests (if you're not using session-based authentication for the API)
-        # If you plan to use this API with external services or simple curl commands without complex auth, this is common.
-        # For more secure APIs, you'd implement token-based authentication.
-        skip_before_action :verify_authenticity_token
+  module V1
+    class BooksController < ApplicationController
+      skip_before_action :verify_authenticity_token
+      before_action :authenticate_api_token!
 
-        # GET /api/v1/books
-        def index
-          @books = Book.all
-          render json: @books
-        end
+      # GET /api/v1/books
+      def index
+        @books = Book.all
+        render json: @books
+      end
 
-        # GET /api/v1/books/:id
-        def show
-          @book = Book.find(params[:id])
-          render json: @book
-        rescue ActiveRecord::RecordNotFound
-          render json: { error: "Book not found" }, status: :not_found
-        end
+      # GET /api/v1/books/:id
+      def show
+        @book = Book.find(params[:id])
+        render json: @book
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Book not found" }, status: :not_found
+      end
 
-        # POST /api/v1/books
-        def create
-          @book = Book.new(book_params)
-          if @book.save
-            render json: @book, status: :created # 201 Created
-          else
-            render json: @book.errors, status: :unprocessable_entity # 422 Unprocessable Entity
-          end
-        end
-
-        # PUT/PATCH /api/v1/books/:id
-        def update
-          @book = Book.find(params[:id])
-          if @book.update(book_params)
-            render json: @book
-          else
-            render json: @book.errors, status: :unprocessable_entity
-          end
-        rescue ActiveRecord::RecordNotFound
-          render json: { error: "Book not found" }, status: :not_found
-        end
-
-        # DELETE /api/v1/books/:id
-        def destroy
-          @book = Book.find(params[:id])
-          @book.destroy
-          head :no_content # 204 No Content
-        rescue ActiveRecord::RecordNotFound
-          render json: { error: "Book not found" }, status: :not_found
-        end
-
-        private
-
-        def book_params
-          # Strong Parameters: Whitelist the parameters you allow for create/update
-          params.require(:book).permit(
-            :title, :author, :isbn_10, :isbn_13,
-            :publication_year, :publisher, :page_count,
-            :description, :cover_image_url, :open_library_id,
-            :series_id, :status, :rating, :comments, :book_type,
-            :date_added, :date_started, :date_finished
-          )
+      # POST /api/v1/books
+      def create
+        @book = Book.new(book_params)
+        if @book.save
+          render json: @book, status: :created
+        else
+          render json: @book.errors, status: :unprocessable_entity
         end
       end
+
+      # PUT/PATCH /api/v1/books/:id
+      def update
+        @book = Book.find(params[:id])
+        if @book.update(book_params)
+          render json: @book
+        else
+          render json: @book.errors, status: :unprocessable_entity
+        end
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Book not found" }, status: :not_found
+      end
+
+      # DELETE /api/v1/books/:id
+      def destroy
+        @book = Book.find(params[:id])
+        @book.destroy
+        head :no_content
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Book not found" }, status: :not_found
+      end
+
+      private
+
+      def authenticate_api_token!
+        expected = Rails.application.credentials.api_token || ENV["API_TOKEN"]
+        provided  = request.headers["X-Api-Token"]
+
+        unless expected.present? && provided.present? &&
+               ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+          render json: { error: "Unauthorized" }, status: :unauthorized
+        end
+      end
+
+      def book_params
+        params.require(:book).permit(
+          :title, :author, :isbn_10, :isbn_13,
+          :publication_year, :publisher, :page_count,
+          :description, :cover_image_url, :open_library_id,
+          :series_id, :status, :rating, :comments, :book_type,
+          :date_added, :date_started, :date_finished
+        )
+      end
     end
+  end
 end

--- a/test/controllers/api/v1/books_controller_test.rb
+++ b/test/controllers/api/v1/books_controller_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
+  TEST_TOKEN = "test-api-token"
+
   setup do
+    ENV["API_TOKEN"] = TEST_TOKEN
+
     @book = books(:one) # The Fellowship of the Ring
     @minimal_book = books(:minimal_book)
     @complete_book = books(:complete_book)
@@ -27,16 +31,43 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
     }
   end
 
-  test "should get index" do
+  teardown do
+    ENV.delete("API_TOKEN")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Authentication
+  # ---------------------------------------------------------------------------
+
+  test "should return 401 with no token" do
     get api_v1_books_url, as: :json
+    assert_response :unauthorized
+    assert_equal "Unauthorized", JSON.parse(response.body)["error"]
+  end
+
+  test "should return 401 with wrong token" do
+    get api_v1_books_url, headers: { "X-Api-Token" => "wrong-token" }, as: :json
+    assert_response :unauthorized
+  end
+
+  # ---------------------------------------------------------------------------
+  # index
+  # ---------------------------------------------------------------------------
+
+  test "should get index" do
+    get api_v1_books_url, headers: auth_headers, as: :json
     assert_response :success
     response_books = JSON.parse(response.body)
     assert_not_empty response_books
   end
 
+  # ---------------------------------------------------------------------------
+  # create
+  # ---------------------------------------------------------------------------
+
   test "should create book" do
     assert_difference("Book.count") do
-      post api_v1_books_url, params: { book: @valid_attributes }, as: :json
+      post api_v1_books_url, params: { book: @valid_attributes }, headers: auth_headers, as: :json
     end
     assert_response :created
     assert_equal @valid_attributes[:title], Book.last.title
@@ -44,13 +75,17 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
 
   test "should not create book with invalid attributes" do
     assert_no_difference("Book.count") do
-      post api_v1_books_url, params: { book: @invalid_attributes }, as: :json
+      post api_v1_books_url, params: { book: @invalid_attributes }, headers: auth_headers, as: :json
     end
     assert_response :unprocessable_entity
   end
 
+  # ---------------------------------------------------------------------------
+  # show
+  # ---------------------------------------------------------------------------
+
   test "should show book" do
-    get api_v1_book_url(@book), as: :json
+    get api_v1_book_url(@book), headers: auth_headers, as: :json
     assert_response :success
     response_book = JSON.parse(response.body)
     assert_equal @book.id, response_book["id"]
@@ -59,43 +94,54 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should return 404 for non-existent book" do
-    get api_v1_book_url(id: 999999), as: :json
+    get api_v1_book_url(id: 999999), headers: auth_headers, as: :json
     assert_response :not_found
     assert_equal "Book not found", JSON.parse(response.body)["error"]
   end
 
+  # ---------------------------------------------------------------------------
+  # update
+  # ---------------------------------------------------------------------------
+
   test "should update book" do
-    patch api_v1_book_url(@book), params: { book: { title: "Updated Title" } }, as: :json
+    patch api_v1_book_url(@book), params: { book: { title: "Updated Title" } }, headers: auth_headers, as: :json
     assert_response :success
     @book.reload
     assert_equal "Updated Title", @book.title
   end
 
   test "should not update book with invalid attributes" do
-    patch api_v1_book_url(@book), params: { book: @invalid_attributes }, as: :json
+    patch api_v1_book_url(@book), params: { book: @invalid_attributes }, headers: auth_headers, as: :json
     assert_response :unprocessable_entity
     @book.reload
     assert_not_equal @invalid_attributes[:title], @book.title
   end
 
   test "should return 404 when updating non-existent book" do
-    patch api_v1_book_url(id: 999999), params: { book: @valid_attributes }, as: :json
+    patch api_v1_book_url(id: 999999), params: { book: @valid_attributes }, headers: auth_headers, as: :json
     assert_response :not_found
   end
 
+  # ---------------------------------------------------------------------------
+  # destroy
+  # ---------------------------------------------------------------------------
+
   test "should destroy book" do
     assert_difference("Book.count", -1) do
-      delete api_v1_book_url(@book), as: :json
+      delete api_v1_book_url(@book), headers: auth_headers, as: :json
     end
     assert_response :no_content
   end
 
   test "should return 404 when destroying non-existent book" do
-    delete api_v1_book_url(id: 999999), as: :json
+    delete api_v1_book_url(id: 999999), headers: auth_headers, as: :json
     assert_response :not_found
   end
 
+  # ---------------------------------------------------------------------------
   # Edge cases and additional validations
+  # ---------------------------------------------------------------------------
+
   test "should handle book with minimal required fields" do
     minimal_attributes = {
       title: "Minimal Book",
@@ -103,7 +149,7 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
       book_type: "physical_book"
     }
     assert_difference("Book.count") do
-      post api_v1_books_url, params: { book: minimal_attributes }, as: :json
+      post api_v1_books_url, params: { book: minimal_attributes }, headers: auth_headers, as: :json
     end
     assert_response :created
   end
@@ -111,7 +157,7 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
   test "should validate rating range" do
     invalid_rating_attributes = @valid_attributes.merge(rating: 11) # Rating should be 1-10
     assert_no_difference("Book.count") do
-      post api_v1_books_url, params: { book: invalid_rating_attributes }, as: :json
+      post api_v1_books_url, params: { book: invalid_rating_attributes }, headers: auth_headers, as: :json
     end
     assert_response :unprocessable_entity
   end
@@ -124,7 +170,7 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
       isbn_13: "9781234567892"
     )
     assert_difference("Book.count") do
-      post api_v1_books_url, params: { book: book_with_series }, as: :json
+      post api_v1_books_url, params: { book: book_with_series }, headers: auth_headers, as: :json
     end
     assert_response :created
     assert_equal series.id, Book.last.series_id
@@ -139,7 +185,7 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
       isbn_13: "9781234567893"
     )
     assert_difference("Book.count") do
-      post api_v1_books_url, params: { book: book_with_dates }, as: :json
+      post api_v1_books_url, params: { book: book_with_dates }, headers: auth_headers, as: :json
     end
     assert_response :created
   end
@@ -150,7 +196,7 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
       isbn_13: "9781234567894"
     )
     assert_difference("Book.count") do
-      post api_v1_books_url, params: { book: complete_attributes }, as: :json
+      post api_v1_books_url, params: { book: complete_attributes }, headers: auth_headers, as: :json
     end
     assert_response :created
     response_book = JSON.parse(response.body)
@@ -161,8 +207,14 @@ class Api::V1::BooksControllerTest < ActionDispatch::IntegrationTest
 
   test "should handle book with invalid rating from fixture" do
     assert_no_difference("Book.count") do
-      post api_v1_books_url, params: { book: @invalid_rating_book.attributes }, as: :json
+      post api_v1_books_url, params: { book: @invalid_rating_book.attributes }, headers: auth_headers, as: :json
     end
     assert_response :unprocessable_entity
+  end
+
+  private
+
+  def auth_headers
+    { "X-Api-Token" => TEST_TOKEN }
   end
 end


### PR DESCRIPTION
## Summary

- `Api::V1::BooksController` called `skip_before_action :verify_authenticity_token` with no replacement protection, allowing any cross-origin page to make write requests (create/update/destroy) against books
- Adds `before_action :authenticate_api_token!` that reads an `X-Api-Token` header and compares it against the token in `Rails.application.credentials.api_token` or the `API_TOKEN` env var
- Uses `ActiveSupport::SecurityUtils.secure_compare` to prevent timing attacks
- Returns `401 Unauthorized` if the token is absent or incorrect

## Configuration

Set the API token via credentials:
```
rails credentials:edit
# add: api_token: your-secret-token-here
```
Or via environment variable: `API_TOKEN=your-secret-token-here`

## Test plan

- [ ] `GET /api/v1/books` without header returns 401
- [ ] `GET /api/v1/books` with wrong token returns 401
- [ ] `GET /api/v1/books` with correct `X-Api-Token` header returns 200
- [ ] `POST /api/v1/books` without token returns 401
- [ ] Existing API tests still pass (will need token set in test env)