### PR TITLE
Fix N+1 queries via eager loading of associations

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -15,7 +15,7 @@ class BooksController < ApplicationController
     session[:sort_column] = @sort_column if params[:sort]
     session[:sort_direction] = @sort_direction if params[:direction]
 
-    @books = Book.all.order(@sort_column => @sort_direction)
+    @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
   end
 
   # GET /books/1 or /books/1.json
@@ -63,7 +63,7 @@ class BooksController < ApplicationController
       format.turbo_stream do
         @sort_column = session[:sort_column] || "title"
         @sort_direction = session[:sort_direction] || "asc"
-        @books = Book.all.order(@sort_column => @sort_direction)
+        @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
         render turbo_stream: [
           turbo_stream.replace(
             "#{@book_status}_section",
@@ -87,7 +87,7 @@ class BooksController < ApplicationController
       @book_status = restored_book.status
       @sort_column = session[:sort_column] || "title"
       @sort_direction = session[:sort_direction] || "asc"
-      @books = Book.all.order(@sort_column => @sort_direction)
+      @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
       respond_to do |format|
         format.turbo_stream do
           render turbo_stream: [
@@ -175,7 +175,7 @@ class BooksController < ApplicationController
       # Refresh the books data for the view
       @sort_column = session[:sort_column] || "title"
       @sort_direction = session[:sort_direction] || "asc"
-      @books = Book.all.order(@sort_column => @sort_direction)
+      @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
 
       # Clear search results
       @query = ""
@@ -208,7 +208,7 @@ class BooksController < ApplicationController
       # Set sort parameters for the partial
       @sort_column = session[:sort_column] || "title"
       @sort_direction = session[:sort_direction] || "asc"
-      @books = Book.all.order(@sort_column => @sort_direction)
+      @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
 
       respond_to do |format|
         format.turbo_stream # Will render update_status.turbo_stream.erb

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -3,7 +3,7 @@ class SeriesController < ApplicationController
 
   # GET /series or /series.json
   def index
-    @series = Series.all
+    @series = Series.all.includes(:books)
   end
 
   # GET /series/1 or /series/1.json

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -17,7 +17,7 @@
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
         </svg>
-        <span><%= series.books.count %> <%= series.books.count == 1 ? 'book' : 'books' %> in this series</span>
+        <span><%= series.books.size %> <%= series.books.size == 1 ? 'book' : 'books' %> in this series</span>
       </div>
     </div>
   </div>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -38,7 +38,7 @@
       <% if @series.any? %>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <% @series.each_with_index do |series, index| %>
-            <% book_count = series.books.count %>
+            <% book_count = series.books.size %>
             <div class="group bg-white/80 backdrop-blur-sm rounded-2xl shadow-lg hover:shadow-2xl transform hover:-translate-y-1 transition-all duration-300 overflow-hidden">
               <!-- Series Header with Gradient -->
               <div class="bg-gradient-to-r <%= ['from-purple-500 to-pink-500', 'from-blue-500 to-indigo-500', 'from-emerald-500 to-teal-500', 'from-orange-500 to-red-500', 'from-violet-500 to-purple-500', 'from-cyan-500 to-blue-500'][index % 6] %> p-6">


### PR DESCRIPTION
## Summary

Two separate N+1 patterns existed:

**Series index** — `Series.all` loaded with no eager loading; the view called `series.books.count` per row, firing one `COUNT` SQL query per series on every page load.

**Books index/actions** — `Book.all.order(...)` loaded books without `includes(:series)`; the `_book_summary` partial accessed `book.series&.name` per row, firing one `SELECT` per book to load the associated series.

Changes:
- `SeriesController#index`: `Series.all` → `Series.all.includes(:books)`
- `series/index.html.erb` + `series/_series.html.erb`: `.count` → `.size` so the already-loaded in-memory association is used instead of re-querying
- `BooksController`: adds `includes(:series)` to all five `Book.all.order(...)` calls (`index`, `destroy`, `restore`, `add_from_search`, `update_status`)

## Test plan

- [ ] Series index page loads with 1 query for series + 1 query for books (verify via logs), not N+1
- [ ] Books index page loads with 1 query for books + 1 query for series (verify via logs)
- [ ] Book counts on series index still display correctly
- [ ] Series name still appears in books list