### PR TITLE
Extract OpenLibrary search into service, remove self-HTTP-call

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,3 @@
-require "httparty"
-
 class BooksController < ApplicationController
   before_action :set_book, only: %i[ show edit update destroy ]
   before_action :set_sort_params, only: %i[ index destroy restore add_from_search update_status ]
@@ -110,29 +108,10 @@ class BooksController < ApplicationController
     @search_results = []
 
     if @query.present?
-      begin
-        api_url = "#{request.base_url}/api/v1/search"
-        Rails.logger.info "Making API request to: #{api_url} with query: #{@query}"
-        response = HTTParty.get(api_url, query: { query: @query })
-
-        if response.success?
-          @search_results = response.parsed_response
-          Rails.logger.info "API response successful, found #{@search_results.size} results"
-          # Filter out books that are already in the user's collection
-          existing_book_ids = Book.pluck(:open_library_id).compact
-          Rails.logger.info "Existing book IDs: #{existing_book_ids}"
-          @search_results = @search_results.reject { |book| existing_book_ids.include?(book["open_library_id"]) }
-          Rails.logger.info "After filtering, #{@search_results.size} results remain"
-
-          # Sort the search results
-          @search_results = sort_search_results(@search_results, @search_sort_column, @search_sort_direction)
-        else
-          Rails.logger.error "API request failed with status: #{response.code}"
-        end
-      rescue => e
-        Rails.logger.error "Search error: #{e.message}"
-        @search_results = []
-      end
+      results = OpenLibrarySearchService.new.search(@query)
+      existing_open_library_ids = Book.pluck(:open_library_id).compact.to_set
+      @search_results = results.reject { |book| existing_open_library_ids.include?(book["open_library_id"]) }
+      @search_results = sort_search_results(@search_results, @search_sort_column, @search_sort_direction)
     end
 
     respond_to do |format|

--- a/app/services/open_library_search_service.rb
+++ b/app/services/open_library_search_service.rb
@@ -1,0 +1,61 @@
+require "httparty"
+
+class OpenLibrarySearchService
+  SEARCH_URL = "https://openlibrary.org/search.json".freeze
+  FIELDS = %w[
+    key title author_name author_key first_publish_year isbn
+    publisher cover_i edition_key number_of_pages_median lccn oclc
+  ].join(",").freeze
+
+  def search(query)
+    start_time = Time.current
+    response = HTTParty.get(
+      SEARCH_URL,
+      query: { q: query, fields: FIELDS, limit: 10 },
+      headers: { "User-Agent" => "BookshelfRailsApp/1.0" },
+      timeout: 10
+    )
+    duration = ((Time.current - start_time) * 1000).round(2)
+
+    if response.success?
+      results = parse_response(response.parsed_response)
+      Rails.logger.info "[OpenLibrary] #{duration}ms, #{results.size} results for #{query.inspect}"
+      results
+    else
+      Rails.logger.error "[OpenLibrary] Failed with status #{response.code}: #{response.body}"
+      []
+    end
+  rescue HTTParty::Error => e
+    Rails.logger.error "[OpenLibrary] HTTParty error: #{e.message}"
+    []
+  rescue StandardError => e
+    Rails.logger.error "[OpenLibrary] Unexpected error: #{e.message}"
+    []
+  end
+
+  private
+
+  def parse_response(data)
+    return [] unless data && data["docs"]
+
+    data["docs"].map do |doc|
+      isbns = doc["isbn"].is_a?(Array) ? doc["isbn"] : []
+
+      {
+        "open_library_id" => doc["key"]&.split("/")&.last,
+        "title" => doc["title"],
+        "authors" => doc["author_name"].is_a?(Array) ? doc["author_name"] : [ doc["author_name"] ].compact,
+        "author_olids" => doc["author_key"].is_a?(Array) ? doc["author_key"] : [ doc["author_key"] ].compact,
+        "publication_year" => doc["first_publish_year"],
+        "isbn_13" => isbns.find { |isbn| isbn.match?(/^\d{13}$/) || isbn.match?(/^978\d{10}$/) } ||
+                     isbns.find { |isbn| isbn.match?(/^978/) },
+        "isbn_10" => isbns.find { |isbn| isbn.match?(/^\d{9}[\dX]$/) || isbn.match?(/^\d{10}$/) },
+        "publishers" => doc["publisher"].is_a?(Array) ? doc["publisher"] : [ doc["publisher"] ].compact,
+        "page_count" => doc["number_of_pages_median"],
+        "cover_image_url_large" => doc["cover_i"] ? "https://covers.openlibrary.org/b/id/#{doc['cover_i']}-L.jpg" : nil,
+        "cover_image_url_medium" => doc["cover_i"] ? "https://covers.openlibrary.org/b/id/#{doc['cover_i']}-M.jpg" : nil,
+        "edition_olids" => doc["edition_key"].is_a?(Array) ? doc["edition_key"] : [ doc["edition_key"] ].compact
+      }
+    end
+  end
+end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -223,7 +223,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle search API failure gracefully" do
-    stub_request(:get, /example\.com\/api\/v1\/search/)
+    stub_request(:get, /openlibrary\.org\/search\.json/)
       .to_return(status: 500, body: "error")
 
     get search_books_url, params: { query: "test" }
@@ -232,7 +232,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle search network error gracefully" do
-    stub_request(:get, /example\.com\/api\/v1\/search/)
+    stub_request(:get, /openlibrary\.org\/search\.json/)
       .to_raise(HTTParty::Error.new("connection failed"))
 
     get search_books_url, params: { query: "test" }
@@ -312,11 +312,22 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
 
   private
 
+  # Stubs the upstream OpenLibrary API with results expressed in the
+  # already-transformed shape (open_library_id, title, authors, publication_year).
+  # Converts them back to the raw docs format that OpenLibrarySearchService expects.
   def stub_openlibrary_search(results)
-    stub_request(:get, /example\.com\/api\/v1\/search/)
+    docs = results.map do |r|
+      {
+        key: "/works/#{r['open_library_id']}",
+        title: r["title"],
+        author_name: Array(r["authors"]),
+        first_publish_year: r["publication_year"]
+      }.compact
+    end
+    stub_request(:get, /openlibrary\.org\/search\.json/)
       .to_return(
         status: 200,
-        body: results.to_json,
+        body: { docs: docs }.to_json,
         headers: { "Content-Type" => "application/json" }
       )
   end


### PR DESCRIPTION
## Summary

`BooksController#search` was making an HTTP GET to its own `/api/v1/search` endpoint to fetch OpenLibrary results. This caused:
- Two request slots consumed per user search (one inbound, one self-outbound)
- Extra network round-trip latency
- Breakage in environments where the app can't reach itself (some PaaS, containerized setups)
- Silent failure if the internal HTTP call times out or errors

Changes:
- Adds `app/services/open_library_search_service.rb` containing the OpenLibrary HTTP call and response parsing, extracted from `Api::V1::OpenLibrarySearchesController`
- `BooksController#search` now calls `OpenLibrarySearchService.new.search(@query)` directly — no HTTP round-trip
- The service returns string-keyed hashes to match what the views already expect
- Error handling (timeouts, HTTParty failures, unexpected errors) is encapsulated in the service, returning `[]` on any failure
- Removes `require "httparty"` from `BooksController` (no longer needed there)
- Converts `existing_book_ids` to a `Set` for O(1) rejection instead of O(n)

## Test plan

- [ ] Search for a book title — results appear in the search panel
- [ ] Search while logged-in with existing books — already-owned books are filtered from results
- [ ] Verify Rails logs show a direct OpenLibrary HTTP call (no `/api/v1/search` self-call)
- [ ] Simulate OpenLibrary timeout (e.g. firewall rule) — search returns empty results gracefully, no 500