### PR TITLE
Replace @@last_deleted_book class variable with session storage

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,9 +9,6 @@ class BooksController < ApplicationController
   ALLOWED_SORT_DIRECTIONS = %w[asc desc].freeze
   ALLOWED_SEARCH_SORT_COLUMNS = %w[title author publication_year].freeze
 
-  # Temporary in-memory store for last deleted book (for demo purposes)
-  @@last_deleted_book = nil
-
   # GET /books or /books.json
   def index
     @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
@@ -52,8 +49,7 @@ class BooksController < ApplicationController
 
   # DELETE /books/1 or /books/1.json
   def destroy
-    @@last_deleted_book = @book.dup
-    @@last_deleted_book.attributes = @book.attributes
+    session[:last_deleted_book] = @book.attributes
     @book_title = @book.title
     @book_status = @book.status
     @book_id = @book.id
@@ -79,8 +75,9 @@ class BooksController < ApplicationController
   end
 
   def restore
-    if @@last_deleted_book
-      restored_book = Book.create(@@last_deleted_book.attributes.except("id", "created_at", "updated_at"))
+    if session[:last_deleted_book]
+      restored_book = Book.create(session[:last_deleted_book].except("id", "created_at", "updated_at"))
+      session.delete(:last_deleted_book)
       @book_status = restored_book.status
       @books = Book.all.includes(:series).order(@sort_column => @sort_direction)
       respond_to do |format|
@@ -100,7 +97,6 @@ class BooksController < ApplicationController
         end
         format.html { redirect_to books_url, notice: "Restored '#{restored_book.title}'" }
       end
-      @@last_deleted_book = nil
     else
       respond_to do |format|
         format.turbo_stream { head :unprocessable_entity }


### PR DESCRIPTION
## Summary

`@@last_deleted_book` was a class variable used to store the last deleted book for the undo feature. This had several problems:

- **Not thread-safe**: class variables are shared across all instances of the class within a process
- **Not process-safe**: not shared across Puma workers, so undo only worked if the restore request hit the same worker that handled the delete
- **Not user-scoped**: any user could restore another user's last deletion by POSTing to `/books/restore`
- **Not durable**: lost on deploy or restart

Replaces with `session[:last_deleted_book]` which stores the deleted book's attributes in the encrypted, signed, per-user session cookie. Correct under any number of processes or threads.

## Test plan

- [ ] Delete a book — undo notice appears
- [ ] Click undo — book is restored to the correct status section
- [ ] Delete a book in browser A, try to restore in browser B — B's restore returns "No book to restore"
- [ ] Delete a book, restart the server, try to restore — returns "No book to restore" gracefully (session still holds the data across restarts since it's in the cookie)