### PR TITLE
Code quality: remove dead code, fix sort direction, remove scaffold artifacts

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -2,6 +2,7 @@ class BooksController < ApplicationController
   before_action :set_book, only: %i[ show edit update destroy ]
   before_action :set_sort_params, only: %i[ index destroy restore add_from_search update_status ]
   before_action :set_search_sort_params, only: %i[ search ]
+  helper_method :status_title
 
   ALLOWED_SORT_COLUMNS = %w[title author publication_year rating book_type].freeze
   ALLOWED_SORT_DIRECTIONS = %w[asc desc].freeze

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -219,16 +219,6 @@ class BooksController < ApplicationController
       session[:search_sort_direction] = @search_sort_direction if params[:search_direction]
     end
 
-    def format_authors(authors)
-      return "Unknown Author" if authors.blank?
-
-      if authors.is_a?(Array)
-        authors.join(", ")
-      else
-        authors.to_s
-      end
-    end
-
     def status_title(status)
       {
         "want_to_read" => "Want to Read",

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,9 +1,2 @@
 module BooksHelper
-  def status_title(status)
-    {
-      "want_to_read" => "Want to Read",
-      "currently_reading" => "Currently Reading",
-      "read" => "Read"
-    }[status]
-  end
 end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/views/api/v1/open_library_searches/search.html.erb
+++ b/app/views/api/v1/open_library_searches/search.html.erb
@@ -1,4 +1,0 @@
-<div>
-  <h1 class="font-bold text-4xl">Api::V1::OpenLibrarySearches#search</h1>
-  <p>Find me in app/views/api/v1/open_library_searches/search.html.erb</p>
-</div>

--- a/app/views/books/_search_results.html.erb
+++ b/app/views/books/_search_results.html.erb
@@ -4,7 +4,7 @@
     <div class="bg-gradient-to-r from-gray-50 to-gray-100 px-6 py-4 border-b border-gray-200 sticky top-0">
       <div class="grid grid-cols-12 gap-4 text-sm font-semibold text-gray-700">
         <div class="col-span-6">
-          <%= link_to search_books_path(query: @query, search_sort: 'title', search_direction: @search_sort_direction == 'asc' ? 'desc' : 'asc'), 
+          <%= link_to search_books_path(query: @query, search_sort: 'title', search_direction: @search_sort_column == 'title' ? (@search_sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'),
               remote: true, 
               class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
             <span>Title</span>
@@ -20,7 +20,7 @@
           <% end %>
         </div>
         <div class="col-span-3">
-          <%= link_to search_books_path(query: @query, search_sort: 'author', search_direction: @search_sort_direction == 'asc' ? 'desc' : 'asc'), 
+          <%= link_to search_books_path(query: @query, search_sort: 'author', search_direction: @search_sort_column == 'author' ? (@search_sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'),
               remote: true, 
               class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
             <span>Author</span>
@@ -36,7 +36,7 @@
           <% end %>
         </div>
         <div class="col-span-1">
-          <%= link_to search_books_path(query: @query, search_sort: 'publication_year', search_direction: @search_sort_direction == 'asc' ? 'desc' : 'asc'), 
+          <%= link_to search_books_path(query: @query, search_sort: 'publication_year', search_direction: @search_sort_column == 'publication_year' ? (@search_sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'),
               remote: true, 
               class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
             <span>Year</span>

--- a/app/views/books/_status_section.html.erb
+++ b/app/views/books/_status_section.html.erb
@@ -11,7 +11,7 @@
         <div class="bg-gradient-to-r from-gray-50 to-gray-100 px-6 py-4 border-b border-gray-200">
           <div class="grid grid-cols-12 gap-4 text-sm font-semibold text-gray-700">
             <div class="col-span-3">
-              <%= link_to books_path(sort: 'title', direction: @sort_direction == 'asc' ? 'desc' : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
+              <%= link_to books_path(sort: 'title', direction: @sort_column == 'title' ? (@sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
                 <span>Title</span>
                 <% if @sort_column == 'title' %>
                   <svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -25,7 +25,7 @@
               <% end %>
             </div>
             <div class="col-span-2">
-              <%= link_to books_path(sort: 'author', direction: @sort_direction == 'asc' ? 'desc' : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
+              <%= link_to books_path(sort: 'author', direction: @sort_column == 'author' ? (@sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
                 <span>Author</span>
                 <% if @sort_column == 'author' %>
                   <svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -39,7 +39,7 @@
               <% end %>
             </div>
             <div class="col-span-2">
-              <%= link_to books_path(sort: 'series', direction: @sort_direction == 'asc' ? 'desc' : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
+              <%= link_to books_path(sort: 'series', direction: @sort_column == 'series' ? (@sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
                 <span>Series</span>
                 <% if @sort_column == 'series' %>
                   <svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -53,7 +53,7 @@
               <% end %>
             </div>
             <div class="col-span-2">
-              <%= link_to books_path(sort: 'book_type', direction: @sort_direction == 'asc' ? 'desc' : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
+              <%= link_to books_path(sort: 'book_type', direction: @sort_column == 'book_type' ? (@sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
                 <span>Type</span>
                 <% if @sort_column == 'book_type' %>
                   <svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -67,7 +67,7 @@
               <% end %>
             </div>
             <div class="col-span-1">
-              <%= link_to books_path(sort: 'rating', direction: @sort_direction == 'asc' ? 'desc' : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
+              <%= link_to books_path(sort: 'rating', direction: @sort_column == 'rating' ? (@sort_direction == 'asc' ? 'desc' : 'asc') : 'asc'), class: "group flex items-center gap-2 hover:text-blue-600 transition-colors" do %>
                 <span>Rating</span>
                 <% if @sort_column == 'rating' %>
                   <svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

A batch of low-risk code quality fixes:

**Dead code removed:**
- `BooksController#format_authors` private method — defined but never called anywhere
- `BooksHelper#status_title` — duplicated the controller's private method, never used (views receive `title` as a local from the controller)

**Scaffold artifacts removed:**
- `hello_controller.js` — default Stimulus scaffold file left behind, registers a controller that is never referenced
- `app/views/api/v1/open_library_searches/search.html.erb` — default Rails scaffold placeholder containing `"Find me in ..."` debug text; the controller always renders JSON so this template is unreachable

**Sort direction bug fixed** (`_status_section.html.erb`, `_search_results.html.erb`):

Previously all sort column links toggled `@sort_direction` globally, so clicking "Author" while sorted by "Title descending" would sort by Author but set direction to ascending (the opposite of the current direction) rather than the expected descending default. Fixed so:
- Clicking the **current** sort column toggles asc ↔ desc (existing behavior preserved)
- Clicking a **different** column resets direction to `asc`

## Test plan

- [ ] Books page sorted by Title ASC → click Author → sorted by Author ASC ✓
- [ ] Books page sorted by Title DESC → click Author → sorted by Author ASC ✓  
- [ ] Books page sorted by Title ASC → click Title → sorted by Title DESC ✓
- [ ] Same tests on the search results sort headers
- [ ] No JS console errors from missing `hello` Stimulus controller